### PR TITLE
Updated README.md due to LASER updates for WMT 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,11 @@ The following assumes LASER is installed and the LASER environmental variable ha
 
 To embed the Bleualign files using LASER:
 ```
-$LASER/tasks/embed/embed.sh bleualign_data/overlaps.fr fr bleualign_data/overlaps.fr.emb
-$LASER/tasks/embed/embed.sh bleualign_data/overlaps.de de bleualign_data/overlaps.de.emb
+$LASER/tasks/embed/embed.sh bleualign_data/overlaps.fr bleualign_data/overlaps.fr.emb [fra]
+$LASER/tasks/embed/embed.sh bleualign_data/overlaps.de bleualign_data/overlaps.de.emb [deu]
 ```
+
+> Please always refer [here](https://github.com/facebookresearch/LASER/blob/main/tasks/embed/README.md) for the latest usage of this script. The usage may vary across the different versions of LASER.
 
 Note that LASER will not overwrite an embedding file if it exsts, so you may need to run first `rm bleualign_data/overlaps.fr.emb bleualign_data/overlaps.de.emb`.
 


### PR DESCRIPTION
Hi Dr. Thompson! I encountered an issue when following the instructions in [README.md](https://github.com/thompsonb/vecalign/blob/4c195b068db360618e54481abd49f7cd86a952d3/README.md?plain=1#L133-L137). It turns out to be the usage of `embed.sh` script is depreciated, due to the [LASER updates for WMT 22](https://github.com/facebookresearch/LASER/commit/7e60ad2d58a2ac4f0bb722d5cbfbe2dbf584c561?short_path=2a1a100#diff-2a1a100d43636b514ebcecdbe1133519c68fadf654b7e84a3e668a8b8297c154).

I thought this problem could be solved once and for all -- if we put a link to the LASER repository to clarify the usage. The instructions in the LASER repository would be always updated in accordance with their updates!

So I added a few lines to README.md. I really hope this change could help people to better use `vecalign`.

Thanks for taking your time to review this PR!